### PR TITLE
Improve solution for day 6

### DIFF
--- a/rs/day_06/src/lib.rs
+++ b/rs/day_06/src/lib.rs
@@ -63,19 +63,33 @@ impl Input {
         self.races
             .iter()
             .map(|race| {
-                (0..race.time)
-                    .filter(|windup| windup * (race.time - windup) > race.distance)
-                    .count()
+                let min = ((race.time as f64
+                    - ((race.time.pow(2) - (4 * race.distance)) as f64).sqrt())
+                    / 2.0)
+                    .floor() as usize;
+
+                let max = ((race.time as f64
+                    + ((race.time.pow(2) - (4 * race.distance)) as f64).sqrt())
+                    / 2.0)
+                    .ceil() as usize;
+
+                max - (min + 1)
             })
             .product()
     }
 
     pub fn part_2(&self) -> usize {
-        (0..self.combined_race.time)
-            .filter(|windup| {
-                windup * (self.combined_race.time - windup) > self.combined_race.distance
-            })
-            .count()
+        let min = ((self.combined_race.time as f64
+            - ((self.combined_race.time.pow(2) - (4 * self.combined_race.distance)) as f64).sqrt())
+            / 2.0)
+            .floor() as usize;
+
+        let max = ((self.combined_race.time as f64
+            + ((self.combined_race.time.pow(2) - (4 * self.combined_race.distance)) as f64).sqrt())
+            / 2.0)
+            .ceil() as usize;
+
+        max - (min + 1)
     }
 }
 


### PR DESCRIPTION
```
Day 06/parse contents   time:   [261.67 ns 262.40 ns 263.14 ns]
                        change: [-3.5662% -3.0618% -2.5819%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) low mild
  5 (5.00%) high mild
Day 06/part 1           time:   [4.6902 ns 4.7012 ns 4.7144 ns]
                        change: [-95.006% -94.984% -94.963%] (p = 0.00 < 0.05)
                        Performance has improved.
Day 06/part 2           time:   [1.2463 ns 1.2485 ns 1.2509 ns]
                        change: [-100.000% -100.000% -100.000%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  2 (2.00%) high mild
  18 (18.00%) high severe
Day 06/total            time:   [270.49 ns 271.72 ns 272.96 ns]
                        change: [-99.998% -99.998% -99.998%] (p = 0.00 < 0.05)
                        Performance has improved.
```